### PR TITLE
docker Django add

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get install -y devscripts build-essential debhelper pk
 
 # Install pip packages
 RUN pip install pip --upgrade
+RUN pip install Django==2.2.16
 RUN pip install --upgrade --no-cache-dir --src /usr/src -r requirements.txt \
     && pip install pygdal==$(gdal-config --version).* \
     && pip install flower==0.9.4


### PR DESCRIPTION
since `pip` installs requirements in the following order:
![image](https://user-images.githubusercontent.com/57660086/105865109-e2661f80-5ff2-11eb-8d58-7c6791c44551.png)

`Dockerfile` required additional step of installing `django` before any other requirements